### PR TITLE
Catch DBusExecutionException in AbstractBluetoothObject#getTyped().

### DIFF
--- a/src/main/java/com/github/hypfvieh/bluetooth/wrapper/AbstractBluetoothObject.java
+++ b/src/main/java/com/github/hypfvieh/bluetooth/wrapper/AbstractBluetoothObject.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import org.apache.commons.lang3.ClassUtils;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.DBusInterface;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.Variant;
@@ -93,7 +94,7 @@ public abstract class AbstractBluetoothObject {
                 return _type.cast(obj);
             }
 
-        } catch (DBusException _ex) {
+        } catch (DBusException | DBusExecutionException _ex) {
             logger.trace("Error while receiving data from DBUS (Field: {}, Type: {}).", _field, _type, _ex);
         }
         return null;


### PR DESCRIPTION
For example, when the following is executed, `DBusExecutionException(RuntimeException)` will be thrown if the `RSSI` property does not exist in the remote object.
```
bluetoothDevice.getRssi();
```
In this case, at AbstractBluetoothObject.java:
```
    protected <T> T getTyped(String _field, Class<T> _type) {
        try {
            Properties remoteObject = dbusConnection.getRemoteObject("org.bluez", dbusPath, Properties.class);
==>         Object obj = remoteObject.Get(getInterfaceClass().getName(), _field);
            if (ClassUtils.isAssignable(_type, obj.getClass())) {
                return _type.cast(obj);
            }

        } catch (DBusException _ex) {
            logger.trace("Error while receiving data from DBUS (Field: {}, Type: {}).", _field, _type, _ex);
        }
        return null;
    }
```
The above arrow `remoteObject.Get ()` returns `DBusExecutionException(RuntimeException)`, so the program ends without catching the exception.

Therefore, it is good to catch `DBusExecutionException` to avoid program termination.