### PR TITLE
Fix key string of bluetoothDeviceByAdapterMac#get(key) to MAC address…

### DIFF
--- a/src/main/java/com/github/hypfvieh/bluetooth/DeviceManager.java
+++ b/src/main/java/com/github/hypfvieh/bluetooth/DeviceManager.java
@@ -172,7 +172,7 @@ public class DeviceManager {
             findBtDevicesByIntrospection(adapter);
         }
 
-        List<BluetoothDevice> devicelist = bluetoothDeviceByAdapterMac.get(_adapter);
+        List<BluetoothDevice> devicelist = bluetoothDeviceByAdapterMac.get(adapter.getAddress());
         if (devicelist != null) {
             return new ArrayList<>(devicelist);
         }


### PR DESCRIPTION
The first argument of `DeviceManager#scanForBluetoothDevices(String _adapter, int _timeoutMs)` may be e.g. "hci0" or MAC address, but in this I/F,
```
List<BluetoothDevice> devicelist = bluetoothDeviceByAdapterMac.get(_adapter);
```
The key of this map seems to have to be in MAC address format. So I think that `adapter.getAddress()` should be used instead of `_adapter`.
