### PR TITLE
Changed AbstractBluetoothObject#getDbusConnection() from protected to…

### DIFF
--- a/src/main/java/com/github/hypfvieh/bluetooth/wrapper/AbstractBluetoothObject.java
+++ b/src/main/java/com/github/hypfvieh/bluetooth/wrapper/AbstractBluetoothObject.java
@@ -52,7 +52,7 @@ public abstract class AbstractBluetoothObject {
         return dbusPath;
     }
 
-    protected DBusConnection getDbusConnection() {
+    public DBusConnection getDbusConnection() {
         return dbusConnection;
     }
 


### PR DESCRIPTION
… public.

As I wrote at the end of Issues#21, I would be very glad if `AbstractBluetoothObject#getDbusConnection()` is changed from protected to public.

If this fits your method's scope policy.