### PR TITLE
Support profile handler and manager

### DIFF
--- a/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/wrapper/BluetoothDeviceType.java
+++ b/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/wrapper/BluetoothDeviceType.java
@@ -2,9 +2,9 @@ package com.github.hypfvieh.bluetooth.wrapper;
 
 /**
  * Bluetooth device ObjectType identifier.
- * @author hypfvieh
  *
+ * @author hypfvieh
  */
 public enum BluetoothDeviceType {
-    NONE, ADAPTER, DEVICE, GATT_SERVICE, GATT_CHARACTERISTIC, GATT_DESCRIPTOR, BATTERY
+    NONE, ADAPTER, DEVICE, GATT_SERVICE, GATT_CHARACTERISTIC, GATT_DESCRIPTOR, BATTERY, PROFILE, PROFILE_MANAGER
 }

--- a/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/wrapper/ProfileChangeListener.java
+++ b/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/wrapper/ProfileChangeListener.java
@@ -1,0 +1,14 @@
+package com.github.hypfvieh.bluetooth.wrapper;
+
+import org.freedesktop.dbus.FileDescriptor;
+import org.freedesktop.dbus.types.Variant;
+
+import java.util.Map;
+
+public interface ProfileChangeListener {
+    void onProfileConnection(String dbusPath, FileDescriptor fd, Map<String, Variant<?>> fd_properties);
+
+    void onProfileDisconnectRequest(String path);
+
+    void onProfileRelease();
+}

--- a/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/wrapper/ProfileHandler.java
+++ b/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/wrapper/ProfileHandler.java
@@ -1,0 +1,45 @@
+package com.github.hypfvieh.bluetooth.wrapper;
+
+import org.bluez.Profile1;
+import org.bluez.exceptions.BluezCanceledException;
+import org.bluez.exceptions.BluezRejectedException;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.FileDescriptor;
+import org.freedesktop.dbus.types.Variant;
+
+import java.util.Map;
+
+public final class ProfileHandler implements Profile1 {
+    private final String objectPath;
+    private final ProfileChangeListener profileChangeListener;
+
+    public ProfileHandler(String objectPath, ProfileChangeListener profileChangeListener) {
+        this.objectPath = objectPath;
+        this.profileChangeListener = profileChangeListener;
+    }
+
+    @Override
+    public void NewConnection(DBusPath _device, FileDescriptor fd, Map<String, Variant<?>> _fd_properties) throws BluezRejectedException, BluezCanceledException {
+        profileChangeListener.onProfileConnection(_device.getPath(), fd, _fd_properties);
+    }
+
+    @Override
+    public void Release() {
+        profileChangeListener.onProfileRelease();
+    }
+
+    @Override
+    public void RequestDisconnection(DBusPath _device) throws BluezRejectedException, BluezCanceledException {
+        profileChangeListener.onProfileDisconnectRequest(_device.getPath());
+    }
+
+    @Override
+    public String getObjectPath() {
+        return objectPath;
+    }
+
+    @Override
+    public boolean isRemote() {
+        return false;
+    }
+}

--- a/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/wrapper/ProfileManager.java
+++ b/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/wrapper/ProfileManager.java
@@ -1,0 +1,57 @@
+package com.github.hypfvieh.bluetooth.wrapper;
+
+import com.github.hypfvieh.DbusHelper;
+import org.bluez.ProfileManager1;
+import org.bluez.exceptions.BluezAlreadyExistsException;
+import org.bluez.exceptions.BluezDoesNotExistException;
+import org.bluez.exceptions.BluezInvalidArgumentsException;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class ProfileManager extends AbstractBluetoothObject {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final ProfileManager1 rawProfileManager;
+
+    public ProfileManager(DBusConnection _dbusConnection) {
+        super(BluetoothDeviceType.PROFILE_MANAGER, _dbusConnection, "/org/bluez");
+        rawProfileManager = DbusHelper.getRemoteObject(_dbusConnection, getDbusPath(), ProfileManager1.class);
+
+    }
+
+    @Override
+    protected Class<? extends DBusInterface> getInterfaceClass() {
+        return ProfileManager1.class;
+    }
+
+    public boolean registerProfile(String path, String uuid, Map<String, Object> options) {
+        try {
+            rawProfileManager.RegisterProfile(new DBusPath(path), uuid, optionsToVariantMap(options));
+            return true;
+        } catch (BluezAlreadyExistsException e) {
+            logger.debug("Profile already exists (UUID: {}, Path: {}).", uuid, path, e);
+            return true;
+        } catch (BluezInvalidArgumentsException e) {
+            logger.error("Error while registering Profile (UUID: {}, Path: {}).", uuid, path, e);
+            return false;
+        }
+    }
+
+    public boolean unregisterProfile(UUID uuid, String path) {
+        try {
+            rawProfileManager.UnregisterProfile(new DBusPath(path));
+            return true;
+        } catch (BluezDoesNotExistException e) {
+            logger.trace("Profile does not exist (UUID: {}, Path: {}).", uuid, path, e);
+            return false;
+        }
+    }
+
+
+}


### PR DESCRIPTION
With these additions and Robert Middleton's dbus-java-nativefd it is possible to do successful rfcomm connections.

A usage example:
```
       ProfileChangeListener profileChangeListener = new ProfileChangeListener(){
         @Override
        public void onProfileConnection(String dbusPath, FileDescriptor fd, Map<String, Variant<?>> fd_properties) {
           log.debug("onProfileConnection src={}, dev={}, fd={}", getSourcePrefix(), dbusPath, fd.getIntFileDescriptor());
           UnixSocketChannel unixSocketChannel = UnixSocketChannel.fromFD(fd.getIntFileDescriptor());
          .....
       };

        Map<String, Object> profileOptions = new HashMap<>();
        profileOptions.put("Name", "Serial Port");
        profileOptions.put("Role", "client");
        profileOptions.put("RequireAuthentication", false);
        profileOptions.put("RequireAuthorization", false); 
        profileOptions.put("AutoConnect", true); 

        String profilePath = "/profile/Test"; // Needs to end in capitalized name! Change for unique name or share it from family manager and dispatch
        try {
            DBusConnection dbusConnection = bluetoothDevice.getDbusConnection();
            dbusConnection.exportObject(profilePath, new ProfileHandler(profilePath, profileChangeListener));
            ProfileManager profileManager = new ProfileManager(dbusConnection);

            boolean result = profileManager.registerProfile(profilePath, RFCOMM_UUID.toString(), profileOptions);
            if (result) {
                bluetoothDevice.connectProfile(RFCOMM_UUID.toString());
            } else {
                log.warn("Connect stopped. Profile register failed. src={}", getSourcePrefix());
                onConnectFailed();
            }
        } catch (DBusException e) {
            log.error("Connect failed src={}", getSourcePrefix(), e);
            onConnectFailed();
        }
    }
```