### PR TITLE
remove pom file from OSGi bundle #64

### DIFF
--- a/bluez-dbus-osgi/pom.xml
+++ b/bluez-dbus-osgi/pom.xml
@@ -56,7 +56,7 @@
                         <Embed-Dependency>!junit-*,!slf4j*, !mockito*,
                             !logback*, !apiguardian*, !opentest4j*,
                             !objenesis, !org.eclipse.jdt.annotation*,
-                            !byte-buddy*, ;scope=compile|runtime</Embed-Dependency>
+                            !byte-buddy*, *;type=!pom;scope=compile|runtime</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
This PR will remve the `.pom` file from the OSGi bundle, the transitive dependencies form the `.pom` file are still in the OSGi bundle.