### PR TITLE
Evict cached devices on ObjectManager InterfacesRemoved

### DIFF
--- a/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/DeviceManager.java
+++ b/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/DeviceManager.java
@@ -12,6 +12,7 @@ import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.handlers.AbstractPropertiesChangedHandler;
 import org.freedesktop.dbus.handlers.AbstractSignalHandlerBase;
+import org.freedesktop.dbus.interfaces.ObjectManager;
 import org.freedesktop.dbus.messages.DBusSignal;
 import org.freedesktop.dbus.types.Variant;
 import org.slf4j.Logger;
@@ -52,6 +53,56 @@ public class DeviceManager {
      */
     private DeviceManager(DBusConnection _connection) {
         dbusConnection = Objects.requireNonNull(_connection);
+        registerObjectManagerHandler();
+    }
+
+    /**
+     * Registers a handler for the org.freedesktop.DBus.ObjectManager InterfacesRemoved signal that
+     * BlueZ emits whenever it removes a managed object (e.g. a device that is no longer in range or
+     * was explicitly removed). The cached {@link BluetoothDevice} wrappers hold a fixed
+     * {@link org.bluez.Device1} proxy bound to a DBus object path; once BlueZ removes that object the
+     * proxy is stale (method calls fail and its property-change signals stop arriving). Evicting the
+     * cached wrapper here makes the next introspection create a fresh wrapper bound to the current
+     * object, recovering transparently from BlueZ object churn.
+     */
+    private void registerObjectManagerHandler() {
+        try {
+            registerSignalHandler(new AbstractSignalHandlerBase<ObjectManager.InterfacesRemoved>() {
+                @Override
+                public Class<ObjectManager.InterfacesRemoved> getImplementationClass() {
+                    return ObjectManager.InterfacesRemoved.class;
+                }
+
+                @Override
+                public void handle(ObjectManager.InterfacesRemoved _signal) {
+                    if (_signal != null) {
+                        onInterfacesRemoved(_signal.getObjectPath(), _signal.getInterfaces());
+                    }
+                }
+            });
+        } catch (DBusException _ex) {
+            logger.warn("Could not register ObjectManager InterfacesRemoved handler; stale device "
+                    + "objects will not be evicted automatically", _ex);
+        }
+    }
+
+    /**
+     * Evicts a cached {@link BluetoothDevice} whose underlying DBus object has been removed by BlueZ,
+     * so it is recreated (with a live proxy and fresh signal subscriptions) on the next lookup.
+     *
+     * @param _objectPath the removed object path
+     * @param _interfaces the interfaces that were removed for that path
+     */
+    private void onInterfacesRemoved(String _objectPath, List<String> _interfaces) {
+        if (_objectPath == null || _interfaces == null || !_interfaces.contains(Device1.class.getName())) {
+            // only care about removed device objects
+            return;
+        }
+        for (List<BluetoothDevice> devices : bluetoothDeviceByAdapterMac.values()) {
+            if (devices.removeIf(_dev -> _objectPath.equals(_dev.getDbusPath()))) {
+                logger.debug("Evicted stale bluetooth device object {} after BlueZ removed it", _objectPath);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Each cached `BluetoothDevice` holds a `Device1` proxy tied to a fixed DBus object path. When BlueZ drops that object (device goes out of range, gets removed, or is recreated during discovery), the proxy goes stale — calls fail and its property-change signals stop — but the wrapper is never evicted, so anyone holding it is stuck until the `DeviceManager` is recreated.

`DeviceManager` wasn't listening for `InterfacesRemoved`, so it never knew the object was gone.

This adds an `ObjectManager.InterfacesRemoved` handler that drops the cached `BluetoothDevice` (matched by object path) when its `Device1` interface is removed. The next `getDevices()` then rebuilds it against the current object, with a fresh proxy and signal subscriptions.

- Only device removals are acted on; other `InterfacesRemoved` signals are ignored.
- Registration failure is logged and non-fatal.
- Uses the existing `registerSignalHandler(...)`; no API changes.