### PR TITLE
Keep BlueZ device refresh on a snapshot

### DIFF
--- a/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/DeviceManager.java
+++ b/bluez-dbus/src/main/java/com/github/hypfvieh/bluetooth/DeviceManager.java
@@ -514,7 +514,8 @@ public class DeviceManager {
             }
         }
 
-        return bluetoothDeviceByAdapterMac.getOrDefault(_adapterMac, new ArrayList<>());
+        return new ArrayList<>(
+            bluetoothDeviceByAdapterMac.getOrDefault(_adapterMac, new ArrayList<>()));
     }
 
     /**


### PR DESCRIPTION
BlueZ can mutate the device list while the binding iterates it, which was throwing ConcurrentModificationException during refresh and taking the bridge offline. This change returns a snapshot from DeviceManager.getDevices() so the binding iterates stable data and can recover cleanly.

Validated on the live tank setup: the bridge stopped flapping and voltage updates resumed after the fix was deployed.